### PR TITLE
Readme update - removing broken url's

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,6 @@ Do you have already a snack job? Check out here: https://jobs.schrodinger-hat.it
 
 Available at [jobs.schrodinger-hat.it](https://jobs.schrodinger-hat.it/)
 
-# Backend API
-
-Available at https://snackjob.herokuapp.com or http://snackjob-api.schrodinger-hat.it
-
-You can test it out as follow:
-
-`
-curl -X POST http://snackjob-api.schrodinger-hat.it/api/v1/snackjob -d 'name=ciao'
-`
-
 # Credits
 
 [thejoin](https://github.com/thejoin95) & [wabri](https://github.com/wabri)


### PR DESCRIPTION
As Heroku removed free dynos, url's for backend are not found.
#14 